### PR TITLE
Ignore xorg version if apt-cache is not found.

### DIFF
--- a/src/investigator.py
+++ b/src/investigator.py
@@ -316,7 +316,10 @@ class Investigator():
         return gcc_version
 
     def xver(self):
-        xver_version = self.execute('/usr/bin/apt-cache show xorg')
+        try:
+            xver_version = self.execute('/usr/bin/apt-cache show xorg')
+        except FileNotFoundError:
+            xver_version = ""
         ans = re.findall("Version: 1:(.*)\+", xver_version)
         if ans:
             return ans[0]


### PR DESCRIPTION
On Archlinux there is no `apt-cache`. Gracefully ignore the value.