### PR TITLE
Fix crash

### DIFF
--- a/src/investigator.py
+++ b/src/investigator.py
@@ -137,7 +137,9 @@ class Investigator():
             print(e)
             return False
         for x in s.stdout:
-            if re.search(process, x.decode('utf-8')):
+            if type(x).__name__ == 'bytes':
+                x = x.decode('utf-8')
+            if re.search(process, x):
                 return True
         return False
 


### PR DESCRIPTION
In some system(like ubuntu), x is of type 'str'. It will raise `'str' object has no attribute decode`. 

I added a judgment condition to judge the type of x string, if it is bytes, then call the function decode, if not, don’t call.